### PR TITLE
Use NSRect for centerRect. Fixes #2

### DIFF
--- a/Better Paste.sketchplugin
+++ b/Better Paste.sketchplugin
@@ -139,5 +139,5 @@ if ([artboards count] == 0) {
 
 // zoomToFitRect has this lame outcome: if switching to a new artboard it forces zoom to the center of the artboard.
 // So using centerRect instead
-var originalViewportRect = MSRect.rectWithRect(NSMakeRect(-scrollOrigin.x / zoomValue, -scrollOrigin.y / zoomValue, viewportWidth / zoomValue, viewportHeight / zoomValue));
+var originalViewportRect = NSMakeRect(-scrollOrigin.x / zoomValue, -scrollOrigin.y / zoomValue, viewportWidth / zoomValue, viewportHeight / zoomValue);
 [[doc currentView] centerRect: originalViewportRect];


### PR DESCRIPTION
This fixes #2

In Sketch 3.3, centerRect now takes an NSRect (see http://bohemiancoding.com/sketch/support/developer/03-reference/MSContentDrawView.html for more info)
